### PR TITLE
chore: add master branch to doc generation workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: generate
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, master ]
   pull_request:
   workflow_dispatch:
 
@@ -33,7 +33,7 @@ jobs:
           agree-to-terms: true
           token: ${{ secrets.GITHUB_TOKEN }}
   deploy:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: github.ref == github.event.repository.default_branch
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
From @chris-little :

> The workflow on GitHub has not worked so that the PDF that I see is an old version. Can we create an up-to-date version to give to Scott so it can be release to the public for RFC please?

The problem is that the default branch is called `master` (old way) but the workflow is only triggered on `main` (new way).

I've updated the workflow to reflect such. Hope it works!